### PR TITLE
The variable 'LocalDispatchTable' is being used without being initialized

### DIFF
--- a/FstHook/Hook.cpp
+++ b/FstHook/Hook.cpp
@@ -4,7 +4,7 @@
 #include "Hook.h"
 #include "HookDispatch.h"
 
-extern LPVOID DispatchTable;
+extern LPVOID *DispatchTable;
 extern DWORD DispatchTableEnd;
 
 /*
@@ -12,9 +12,9 @@ extern DWORD DispatchTableEnd;
 */
 BOOL AddProxyProcedure(CHAR *FunctionName, DWORD NumParameters, LPVOID ProxyAddress)
 {
-	LPVOID FunctionAddress;
-	LPVOID *LocalDispatchTable;
-	DWORD ordinal, TableSize;
+	DWORD ordinal = 0, TableSize = 0;
+	LPVOID FunctionAddress = NULL;
+	LPVOID *LocalDispatchTable = DispatchTable;
 
 	FunctionAddress = GetProcAddress(GetModuleHandleA("ntdll.dll"), FunctionName);
 	if(!FunctionAddress)

--- a/FstHook/HookDispatch.cpp
+++ b/FstHook/HookDispatch.cpp
@@ -2,7 +2,7 @@
 #include <stdio.h>
 #include "HookDispatch.h"
 
-LPVOID DispatchTable = NULL;
+LPVOID *DispatchTable = NULL;
 DWORD DispatchTableEnd = 0;
 
 /*


### PR DESCRIPTION
The bug happens after calling 'AddProxyProcedure' twice; The second time time with SYSCALL ordinal lower than the first time.